### PR TITLE
Remove contributing guide link and line

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ Found an awesome project, blog, video etc.? Send me a pull request!
 * Please make an individual pull request for each suggestion
 * Make sure the TravisCI tests pass on your pull request
 * Use the following format for links: \[Resource\]\(URL\)
-* Want to suggest a package? Read the [Contribution Guide](https://github.com/chiraggude/awesome-laravel/blob/master/CONTRIBUTING.md)
 * New categories or improvements to the existing categorization are welcome
 
 ## License


### PR DESCRIPTION
The contributing link goes to another project. Proposal to remove it for now, and we can always add it later on.